### PR TITLE
Fix typo causing errors when `Object.defineProperty` is commented out

### DIFF
--- a/Intl.js
+++ b/Intl.js
@@ -23,7 +23,7 @@ var
     // Naive defineProperty for compatibility
     defineProperty = Object.defineProperty || function (obj, name, desc) {
         if (desc.get && obj.__defineGetter__)
-            obj.__defineGetter(name, desc.get);
+            obj.__defineGetter__(name, desc.get);
         else if (desc.value || desc.get)
             obj[name] = desc.value || desc.get;
     },


### PR DESCRIPTION
When using this on Node.js, there was an issue with `Object.defineProperty` (still looking into that bit) so we commented out this portion. This led us to find a typo with a missing __ after defineGetter. Adding in the trailing __ fixed the issue on our end.
