### PR TITLE
using standard polyfill wrapping pattern to access global scope in multiple runtimes

### DIFF
--- a/Intl.js
+++ b/Intl.js
@@ -1,8 +1,9 @@
 /*jshint proto:true, eqnull:true, boss:true, laxbreak:true, newcap:false, shadow:true, funcscope:true */
-if (typeof window !== 'undefined')
-    window.OldIntl = window.Intl;
+(function (globals, Intl) {
 
-var Intl = /*window.Intl || */(function (Intl) {
+if (globals.Intl)
+    globals.OldIntl = globals.Intl;
+globals.Intl = Intl;
 
 /**
  * @license Copyright 2013 Andy Earnshaw, MIT License
@@ -2926,5 +2927,4 @@ function getInternalProperties (obj) {
         return objCreate(null);
 }
 
-return Intl;
-})({});
+})(this, {});


### PR DESCRIPTION
Accessing `window` object directly is not recommended because it bound this polyfill to a browser. Other polyfills are using a more elegant solution to access the global scope.

With this PR, we can guarantee:
- using `this` (which is `window` in the browser, and `global` in nodejs) as the global scope to augment it with `Intl` member.
- preserving `OldIntl` on the global scope (even though it is not used in this script at the moment).
- a new `Intl` will be created everytime that this script gets evaluated.
