### PR TITLE
adding all locale data by default

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,20 @@
+/**
+This script is the main script when running in nodejs environment, and includes
+the core features of the polyfill plus all available locales:
+
+var Intl = require('Intl.js');
+**/
+var Intl = require('./polyfill'),
+    fs = require('fs'),
+    path = require('path'),
+    folder = path.join(__dirname, '../locale-data/json/');
+
+// attaching all available locales under locale-data
+fs.readdirSync(folder).forEach(function (filename) {
+    if (path.extname(filename) === '.json') {
+        Intl.__addLocaleData(require(folder + filename));
+    }
+});
+
+// exporting Intl with all locales available
+module.exports = Intl;

--- a/lib/polyfill.js
+++ b/lib/polyfill.js
@@ -1,0 +1,9 @@
+/**
+This script is useful for the case where you want to load the core features
+without the locale data:
+
+var Intl = require('Intl.js/lib/polyfill');
+Intl.__addLocaleData(require('Intl.js/locale-data/json/de-AT.json'));
+**/
+
+module.exports = require('../Intl.js');

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "Intl.js",
     "version": "0.0.1",
     "description": "polyfill the ECMA-402 Intl API (except collation)",
-    "main": "Intl.js",
+    "main": "./lib",
     "directories": {
         "test": "tests"
     },


### PR DESCRIPTION
**DO NOT MERGE YET, WE ARE STILL DISCUSSING THIS APPROACH**

This PR solves part of the problem described in Issue #20.

The default way of loading the polyfill in a nodejs environment will be:

```
var Intl = require('Intl.js');
```

and as a result, you get a polyfill with all the available locales already added thru `Intl.__addLocaleData()`, and you should be ready to do. But this operation is a little expensive, specially if you only need one locale or a handful of locales (a la whitelisted), and for that, you might want to optimize your program to add the specific locales that you know you will need. Here is an example of how to do that:

```
var Intl = require('Intl.js/polyfill');
Intl.__addLocaleData(require('Intl.js/locale-data/json/de-AT.json'));
```
