### PR TITLE
Unignore the locale-data/ from npm package so its contents can be served

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -10,9 +10,6 @@ cldr/
 # d8 artifact
 .d8_history
 
-# Locale data is already present in Intl.complete.js
-locale-data/
-
 # The NPM package only needs runtime files.
 # (It doesn't need anything used during development of this library.)
 tools/


### PR DESCRIPTION
Currently the Bower package contains `locale-data/` dir, and even though the npm package contains `Intl.complete.js`, it's not practical to serve because of its size. Including the `locale-data/` dir makes it easier for people to efficiently serve `Intl.min.js` along with a negotiated locale resource pack.
