### PR TITLE
added IE8 to cover browsers with only ES3 support

### DIFF
--- a/tests/saucelabs.js
+++ b/tests/saucelabs.js
@@ -49,6 +49,11 @@ var LIBS = {
             platform: "Windows 8"
         },
         {
+            browserName: "internet explorer",
+            version: "8",
+            platform: "Windows 7"
+        },
+        {
             browserName: "safari",
             version: "7",
             platform: "OS X 10.9"


### PR DESCRIPTION
@ericf mentioned that we should also probably be testing in a browser that only supports ES3. An example of such a browser is IE8.
