### PR TITLE
Fix the following issue: When converting from cldr data.json to Intl.js ...

### DIFF
--- a/tools/Ldml2Json.js
+++ b/tools/Ldml2Json.js
@@ -413,7 +413,7 @@ function processObj(data) {
                 order
                     .replace('{0}', avail[frmt[0]] || '')
                     .replace('{1}', dFrmt || '')
-                    .replace(/^[^a-z0-9]+|[^a-z0-9]+$/gi, '')
+                    .replace(/^[,\s]+|[,\s]+$/gi, '')
             );
         });
     });


### PR DESCRIPTION
Fix the following issue: When converting from cldr data.json to Intl.js *.json files, some Date/Time formats' last character was missing.
