### PR TITLE
Always include latn numeric system in locale data

### DIFF
--- a/tasks/utils/reduce.js
+++ b/tasks/utils/reduce.js
@@ -27,13 +27,14 @@ module.exports = function processObj(locale, data) {
         gopv = function (o) {
             return o ? Object.getOwnPropertyNames(o).map(function (e) { return o[e]; }) : undefined;
         },
+        latnNu = 'latn',
 
         // Copy numbering systems
         defaultNu   = data.numbers.defaultNumberingSystem,
         otherNu     = gopn(data.numbers.otherNumberingSystems).map(function(key) {
                         return data.numbers.otherNumberingSystems[key];
                     }).filter(function (key) {
-                        return key !== defaultNu;
+                        return key !== defaultNu && key !== latnNu;
                     }),
 
         // Map calendar names to BCP 47 unicode extension 'ca' keys
@@ -76,11 +77,11 @@ module.exports = function processObj(locale, data) {
                 hour12: !/H|k/.test(defaultTimeFormat),
 
                 formats: [],
-                calendars: {},
+                calendars: {}
             },
             number: {
                 // Numbering systems, with the default first
-                nu: [ defaultNu ],
+                nu: (defaultNu === latnNu) ? [ latnNu ] : [ defaultNu, latnNu ],
 
                 // Formatting patterns
                 patterns: {},


### PR DESCRIPTION
Solves #90 for `latn` numeric system.

This change will only affect locales whose default numeric system is not latn.  For these locale data files one string will be added into `nu` array in the `number` section in locale data files. For example for `locale-data/json/ar-AE.json` the change will be:

```javascript
     "number": {
         "nu": [
            "arab",
            "latn"
         ],
```

instead of original:

```javascript
     "number": {
         "nu": [
            "arab"
         ],
```