### PR TITLE
Use correct width for weekday names

### DIFF
--- a/tasks/utils/reduce.js
+++ b/tasks/utils/reduce.js
@@ -156,7 +156,7 @@ module.exports = function processObj(locale, data) {
         }
         if ((frmt = data.calendars[cal].days) && (frmt = frmt.format)) {
             obj.days = {
-                narrow: gopv(frmt.short),
+                narrow: gopv(frmt.narrow),
                 short:  gopv(frmt.abbreviated),
                 long:   gopv(frmt.wide)
             };


### PR DESCRIPTION
This PR resolves #92

This will hardly have any impact on size of locale data files. In most cases locale data files will become a bit smaller because `narrow` weekdays names tend to be smaller than `short` ones.