### PR TITLE
Fix Object.defineProperty feature detection

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -20,8 +20,13 @@ import {
 var Intl = {},
 
     realDefineProp = (function () {
-        try { return !!Object.defineProperty({}, 'a', {}); }
-        catch (e) { return false; }
+        var sentinel = {};
+        try {
+            Object.defineProperty(sentinel, 'a', {});
+            return 'a' in sentinel;
+        } catch (e) {
+            return false;
+        }
     })(),
 
     // Need a workaround for getters in ES3


### PR DESCRIPTION
The feature test that checked if Object.defineProperty was working
correctly wasn't actually testing that it defined properties. This
caused conflicts with shams in IE 8 and below.