### PR TITLE
falling back to the value of `hour12` from the produced formats

### DIFF
--- a/src/cldr.js
+++ b/src/cldr.js
@@ -4,7 +4,7 @@
 var expDTComponents = /(?:[Eec]{1,6}|G{1,5}|(?:[yYu]+|U{1,5})|[ML]{1,5}|d{1,2}|a|[hkHK]{1,2}|m{1,2}|s{1,2}|z{1,4})(?=([^']*'[^']*')*[^']*$)/g;
 
 // Skip over patterns with these datetime components
-var unwantedDTCs = /[QxXVOvZASjgFDwWIQqH]/;
+var unwantedDTCs = /[QxXVOvZASjgFDwWIQq]/;
 
 // Maps the number of characters in a CLDR pattern to the specification
 var dtcLengthMap = {
@@ -107,11 +107,14 @@ export function createDateTimeFormat(format) {
     formatObj.pattern = formatObj.pattern.replace(/'([^']*)'/g, function ($0, literal) {
         return literal ? literal : "'";
     });
+    // Pattern for 12 hours inherit from pattern by default.
+    formatObj.pattern12 = formatObj.pattern;
 
     if (formatObj.pattern.indexOf('{ampm}') > -1) {
         formatObj.hour12 = true;
-        formatObj.pattern12 = formatObj.pattern;
         formatObj.pattern = formatObj.pattern.replace('{ampm}', '').replace(/^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g, '');
+    } else {
+        formatObj.hour12 = false;
     }
 
     return formatObj;

--- a/src/core.js
+++ b/src/core.js
@@ -1944,8 +1944,9 @@ function/* 12.1.1.1 */InitializeDateTimeFormat (dateTimeFormat, locales, options
         pattern,
 
     // 31. Let hr12 be the result of calling the GetOption abstract operation with
-    //     arguments options, "hour12", "boolean", undefined, and undefined.
-        hr12 = GetOption(options, 'hour12', 'boolean'/*, undefined, undefined*/);
+    //     arguments options, "hour12", "boolean", undefined, and the internal
+    //     value of "hour12" from the best format match as the result back value.
+        hr12 = GetOption(options, 'hour12', 'boolean', undefined, bestFormat.hour12);
 
     // 32. If dateTimeFormat has an internal property [[hour]], then
     if (internal['[[hour]]']) {


### PR DESCRIPTION
cldr calendar data is produced by analyzing each date/time formats. As part of this process, each pattern should produce two variations, `pattern` and `pattern12` in case the user specify `hour12`, or the default value for `hour12` is true.

This PR introduces a way to control what pattern to display if the user is not providing an explicit value for hour12 in the options, falling back to the computed value of hour12 from formats.

This PR partially solves https://github.com/andyearnshaw/Intl.js/issues/119