### PR TITLE
Clarify polyfill code

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ if (global.Intl) {
     if (!areIntlLocalesSupported(localesMyAppSupports)) {
         // `Intl` exists, but it doesn't have the data we need, so load the
         // polyfill and replace the constructors with need with the polyfill's.
-        require('intl'); // declares global var 'IntlPolyfill'
+        var IntlPolyfill = require('intl'); // will not replace global Intl since it already exists
         Intl.NumberFormat   = IntlPolyfill.NumberFormat;
         Intl.DateTimeFormat = IntlPolyfill.DateTimeFormat;
     }

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ if (global.Intl) {
     if (!areIntlLocalesSupported(localesMyAppSupports)) {
         // `Intl` exists, but it doesn't have the data we need, so load the
         // polyfill and replace the constructors with need with the polyfill's.
-        require('intl');
+        require('intl'); // declares global var 'IntlPolyfill'
         Intl.NumberFormat   = IntlPolyfill.NumberFormat;
         Intl.DateTimeFormat = IntlPolyfill.DateTimeFormat;
     }


### PR DESCRIPTION
When I first read this code, I thought there was a bug and that it ought to be `var IntlPolyfill = require('intl');`

FormatJS guys [pointed out](https://github.com/yahoo/formatjs-site/pull/200/files#r39440912) that `require('intl');` was declaring `IntlPolyfill` as a global variable.

I think this little clarification would be welcome.