### PR TITLE
fix {percentSign} in FormatNumberToParts

### DIFF
--- a/src/11.numberformat.js
+++ b/src/11.numberformat.js
@@ -575,7 +575,7 @@ function FormatNumberToParts (numberFormat, x) {
             arrPush.call(result, { type: 'plusSign', value: ild.plusSign });
         } else if (p === '{minusSign}') {
             arrPush.call(result, { type: 'minusSign', value: ild.minusSign });
-        } else if (p === '{percent}' && internal['[[style]]'] === 'percent') {
+        } else if (p === '{percentSign}' && internal['[[style]]'] === 'percent') {
             arrPush.call(result, { type: 'percentSign', value: ild.percentSign });
         } else if (p === '{currency}' && internal['[[style]]'] === 'currency') {
             let cd,


### PR DESCRIPTION
A small change to fix https://github.com/andyearnshaw/Intl.js/commit/b5d39ad0a3cb502ea1133a9398261e38f20d32d6#commitcomment-16380172