### PR TITLE
Unify token matching in Format{DateTime,Number}ToParts

### DIFF
--- a/src/11.numberformat.js
+++ b/src/11.numberformat.js
@@ -457,11 +457,9 @@ function FormatNumberToParts (numberFormat, x) {
         if (beginIndex > nextIndex)
             arrPush.call(result, { type: 'literal', value: pattern.substring(nextIndex, beginIndex) });
 
-        nextIndex = endIndex + 1;
+        let p = pattern.substring(beginIndex + 1, endIndex);
 
-        let p = pattern.substring(beginIndex, nextIndex);
-
-        if (p === '{number}') {
+        if (p === 'number') {
             if (isNaN(x))
                 arrPush.call(result, { type: 'nan', value: ild.nan });
             if (!isFinite(x))
@@ -571,13 +569,13 @@ function FormatNumberToParts (numberFormat, x) {
                 arrPush.call(result, { type: 'fraction', value: fraction });
             }
 
-        } else if (p === '{plusSign}') {
+        } else if (p === 'plusSign') {
             arrPush.call(result, { type: 'plusSign', value: ild.plusSign });
-        } else if (p === '{minusSign}') {
+        } else if (p === 'minusSign') {
             arrPush.call(result, { type: 'minusSign', value: ild.minusSign });
         } else if (p === '{percentSign}' && internal['[[style]]'] === 'percent') {
             arrPush.call(result, { type: 'percentSign', value: ild.percentSign });
-        } else if (p === '{currency}' && internal['[[style]]'] === 'currency') {
+        } else if (p === 'currency' && internal['[[style]]'] === 'currency') {
             let cd,
             // a. Let currency be the value of the [[currency]] internal property of
             //    numberFormat.
@@ -609,9 +607,10 @@ function FormatNumberToParts (numberFormat, x) {
 
             arrPush.call(result, { type: 'currency', value: cd });
         } else {
-            arrPush.call(result, { type: 'literal', value: p });
+            arrPush.call(result, { type: 'literal', value: pattern.substring(beginIndex, endIndex + 1) });
         }
 
+        nextIndex = endIndex + 1;
         beginIndex = pattern.indexOf('{', nextIndex);
     }
 

--- a/src/12.datetimeformat.js
+++ b/src/12.datetimeformat.js
@@ -879,7 +879,7 @@ function CreateDateTimeParts(dateTimeFormat, x) {
             } else {
               arrPush.call(result, {
                 type: 'literal',
-                value: pattern.substring(beginIndex, endIndex),
+                value: pattern.substring(beginIndex, endIndex + 1),
               });
             }
             // h.


### PR DESCRIPTION
This is a fix to the polyfill which follows the update to the `formatToParts` spec as proposed in https://github.com/zbraniecki/ecma402/pull/2/.