### PR TITLE
Fix Intl references

### DIFF
--- a/src/13.locale-sensitive-functions.js
+++ b/src/13.locale-sensitive-functions.js
@@ -2,6 +2,10 @@
 // ===========================================================================
 
 import {
+    Intl,
+} from "./8.intl.js";
+
+import {
     FormatNumber,
     NumberFormatConstructor,
 } from "./11.numberformat.js";

--- a/src/main.js
+++ b/src/main.js
@@ -2,7 +2,7 @@ import IntlPolyfill from "./core.js";
 
 // hack to export the polyfill as global Intl if needed
 if (typeof Intl !== undefined) {
-    Intl = IntlPolyfill;
+    global.Intl = IntlPolyfill;
     IntlPolyfill.__applyLocaleSensitivePrototypes();
 }
 


### PR DESCRIPTION
Fix references to `Intl`.

Note: I'm uncertain about c716370. `npm run build` wasn't running cleanly for me. The diff also appear to include a number of changes I personally didn't make, but rather are attributed to version differences in dependencies that I installed vs whomever made the last build. I'd be happy to drop that commit if needed.