### PR TITLE
Replace for-in with basic for loop in FormatNumber

### DIFF
--- a/src/11.numberformat.js
+++ b/src/11.numberformat.js
@@ -704,8 +704,8 @@ export function FormatNumber(numberFormat, x) {
     // 2. Let result be an empty String.
     let result = '';
     // 3. For each part in parts, do:
-    for (let idx in parts) {
-        let part = parts[idx];
+    for (let i = 0; parts.length > i; i++) {
+        let part = parts[i];
         // a. Set result to a String value produced by concatenating result and part.[[value]].
         result += part['[[value]]'];
     }


### PR DESCRIPTION
Fixes: https://github.com/andyearnshaw/Intl.js/issues/176.

Basically `for-in` loop iterate over all enumerable properties of the object itself and those the object inherits from its constructor's prototype. In the FormatNumber function, the parts Object is from [List](https://github.com/andyearnshaw/Intl.js/blob/master/src/util.js#L116-L124) and that can be parent Object. To fix it, I think we should add a [`hasOwnProperty` check](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...in#Examples) into `for-in` loop or use this simple way.