### PR TITLE
BestFitFormatMatcher: Add new penalty as a pattern

### DIFF
--- a/src/12.datetimeformat.js
+++ b/src/12.datetimeformat.js
@@ -626,6 +626,8 @@ function BestFitFormatMatcher (options, formats) {
     // 6. Let shortMorePenalty be 3.
     let shortMorePenalty = 3;
 
+    let patternPenalty = 2;
+
     let hour12Penalty = 1;
 
     // 7. Let bestScore be -Infinity.
@@ -663,6 +665,12 @@ function BestFitFormatMatcher (options, formats) {
             // iii. If formatPropDesc is not undefined, then
             //     1. Let formatProp be the result of calling the [[Get]] internal method of format with argument property.
             let formatProp = hop.call(format, property) ? format[property] : undefined;
+
+            let patternProp = hop.call(format._, property) ? format._[property] : undefined;
+
+            if (optionsProp !== patternProp) {
+              score -= patternPenalty;
+            }
 
             // iv. If optionsProp is undefined and formatProp is not undefined, then decrease score by
             //     additionPenalty.


### PR DESCRIPTION
Fixes https://github.com/andyearnshaw/Intl.js/issues/152 and https://github.com/andyearnshaw/Intl.js/issues/179.

In the InitializeDateTimeFormat, pattern prop as a `_` is checked by diverging and it will be used when the value is matched.