### PR TITLE
Add npm run test into before_install in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
 before_install:
   - npm install -g npm@3
   - npm --version
+  - npm install
   - npm run build
 addons:
   sauce_connect:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
 before_install:
   - npm install -g npm@3
   - npm --version
+  - npm run build
 addons:
   sauce_connect:
     username: andyearnshaw


### PR DESCRIPTION
To avoid from conflicting the build files in the `dist` directory with each pull requests, we usually don't include the build file to pull requests. Then travis should build it on the CI server before run the tests.