### PR TITLE
Add newDateUTC to run the sanity.js on CI

### DIFF
--- a/tests/sanity.js
+++ b/tests/sanity.js
@@ -10,6 +10,14 @@ function assert(value, expected, message) {
     }
 }
 
+function newDateUTC() {
+  var date = new Date(...arguments)
+  var localTime = date.getTime();
+  var localOffset = date.getTimezoneOffset() * 60000;
+  var utc = localTime + localOffset;
+  return new Date(utc);
+}
+
 assert(new IntlPolyfill.NumberFormat('de-DE', {
     minimumFractionDigits: 2,
     maximumFractionDigits: 2
@@ -30,7 +38,9 @@ assert(new IntlPolyfill.DateTimeFormat('en', {
 assert(new IntlPolyfill.DateTimeFormat('en-US', {
     hour: 'numeric',
     minute: 'numeric'
-}).format(new Date('Tue Mar 01 2016 14:08:39 GMT-0500 (EST)')), '2:08 PM', 'missing leading 0 on minutes');
+}).format(newDateUTC('Tue Mar 01 2016 14:08:39 GMT-0500 (EST)')), '7:08 PM', 'missing leading 0 on minutes');
+
+// Issue #173
 assert(new IntlPolyfill.DateTimeFormat('en-GB', {
   hour: '2-digit',
   hour12: false,


### PR DESCRIPTION
The following test case can be falling depending on the timezone of the machine execute tests(e.g. the error on CI). To fix the red light, let me add a helper function to create a Date object from UTC into the `sanity.js`.
+ https://github.com/andyearnshaw/Intl.js/blob/ec31f6fa2ab5d46fcf671ff5a0f0bc29eafae7c8/tests/sanity.js#L33