### PR TITLE
Allow disable of RegExp cache/restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,14 @@ is automatically added to the runtime and does not need to be provided.
 Contents of the `locale-data` directory are a modified form of the Unicode CLDR
 data found at http://www.unicode.org/cldr/.
 
+## RegExp cache / restore
+`Intl.js` attempts to cache and restore static RegExp properties before executing any
+regular expressions in order to comply with ECMA-402.  This process is imperfect,
+and some situations are not supported.  For example, you may experience errors when
+attempting to use `Intl.js` methods immediately after executing a regular expression
+against a very long input.  This behavior is not strictly necessary, and is only
+required if the app depends on RegExp static properties not changing (which is highly
+unlikely).  To disable this functionality, invoke `Intl.__disableRegExpRestore()`.
 
 ## Contribute
 

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "build:dist": "npm run build:dist:dev && npm run build:dist:prod",
     "build": "npm run build:data && npm run build:lib && npm run build:dist",
     "lint": "eslint .",
-    "test": "cd tests && node polyfilling.js && node sanity.js && node noderunner.js && node saucelabs.js",
+    "test": "cd tests && node polyfilling.js && node sanity.js && node noderunner.js && node saucelabs.js && node disableregexprestore.js",
     "pretest": "npm run lint",
     "preversion": "npm run clean && npm run build && npm run test",
     "prepublish": "npm run clean && npm run build"

--- a/src/core.js
+++ b/src/core.js
@@ -93,4 +93,10 @@ function addLocaleData (data, tag) {
         setDefaultLocale(tag);
 }
 
+defineProperty(Intl, '__disableRegExpRestore', {
+    value: function () {
+        internals.disableRegExpRestore = true;
+    }
+});
+
 export default Intl;

--- a/src/util.js
+++ b/src/util.js
@@ -132,6 +132,10 @@ List.prototype = objCreate(null);
  * Constructs a regular expression to restore tainted RegExp properties
  */
 export function createRegExpRestore () {
+    if (internals.disableRegExpRestore) {
+        return { exp: /a/, input: 'a' };
+    }
+
     let esc = /[.?*+^$[\]\\(){}|-]/g,
         lm  = RegExp.lastMatch || '',
         ml  = RegExp.multiline ? 'm' : '',

--- a/tests/disableregexprestore.js
+++ b/tests/disableregexprestore.js
@@ -1,0 +1,40 @@
+var IntlPolyfill = require('../');
+
+function assertEqual(value, expected, message) {
+    console.log(message);
+    if (value !== expected) {
+        console.error(' > ERROR: expected value ' + expected + ' but the actual value is ' + value);
+        process.exit(1);
+    } else {
+        console.log(' > PASSED');
+    }
+}
+
+function assertNotEqual(value, expected, message) {
+    console.log(message);
+    if (value === expected) {
+        console.error(' > ERROR: expected value ' + expected + ' but the actual value is ' + value);
+        process.exit(1);
+    } else {
+        console.log(' > PASSED');
+    }
+}
+
+/foo/.exec('a foo test');
+new IntlPolyfill.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'GBP',
+    minimumFractionDigits: 2,
+});
+assertEqual(RegExp.input, 'a foo test', 'Normally, RegExp.input should be cached and restored');
+assertEqual(RegExp.lastMatch, 'foo', 'Normally, RegExp.lastMatch should be cached and restored');
+
+IntlPolyfill.__disableRegExpRestore();
+/foo/.exec('a foo test');
+new IntlPolyfill.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'GBP',
+    minimumFractionDigits: 2,
+});
+assertNotEqual(RegExp.input, 'a foo test', 'After invoking __disableRegExpRestore, RegExp.input should not be cached and restored');
+assertNotEqual(RegExp.lastMatch, 'foo', 'After invoking __disableRegExpRestore, RegExp.lastMatch should not be cached and restored');


### PR DESCRIPTION
Fixes #196.

The implementation of cache/restore of RegExp properties
has the potential to cause a number of issues.  A perfect
solution is not possible because it's not possible to
determine the regex that was used to turn the cached input
into the cached match and group matches.  The current
solution simply takes the lastMatch and escapes it,
wrapping any match groups in parens.  One problem with
this approach is that when the match is very long, it
will overrun the maximum length of a RegEx in JavaScript.

In this commit, we add the capability to disable restore
of RegExp properties entirely, via
`IntlPolyfill.__disableRegExpRestore`.