### PR TITLE
Do not fail if RegExp too big

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,16 @@ Contents of the `locale-data` directory are a modified form of the Unicode CLDR
 data found at http://www.unicode.org/cldr/.
 
 
+## RegExp cache / restore
+`Intl.js` attempts to cache and restore static RegExp properties before executing any
+regular expressions in order to comply with ECMA-402.  This process is imperfect,
+and some situations are not supported.  For example, you may experience errors when
+attempting to use `Intl.js` methods immediately after executing a regular expression
+against a very long input.  If a RegExp is processed that is too big a warning
+will be thrown to the console.  The resulting state of the RegExp properties is
+undefined, meaning they may or may not have been modified.
+
+
 ## Contribute
 
 See the [CONTRIBUTING file][] for info.

--- a/src/11.numberformat.js
+++ b/src/11.numberformat.js
@@ -76,7 +76,7 @@ export function /*11.1.1.1 */InitializeNumberFormat (numberFormat, locales, opti
     let internal = getInternalProperties(numberFormat);
 
     // Create an object whose props can be used to restore the values of RegExp props
-    let regexpState = createRegExpRestore();
+    let regexpRestore = createRegExpRestore();
 
     // 1. If numberFormat has an [[initializedIntlObject]] internal property with
     // value true, throw a TypeError exception.
@@ -300,7 +300,7 @@ export function /*11.1.1.1 */InitializeNumberFormat (numberFormat, locales, opti
         numberFormat.format = GetFormatNumber.call(numberFormat);
 
     // Restore the RegExp properties
-    regexpState.exp.test(regexpState.input);
+    regexpRestore();
 
     // Return the newly initialised object
     return numberFormat;
@@ -339,7 +339,7 @@ defineProperty(Intl.NumberFormat, 'supportedLocalesOf', {
             throw new TypeError('supportedLocalesOf() is not a constructor');
 
         // Create an object whose props can be used to restore the values of RegExp props
-        let regexpState = createRegExpRestore(),
+        let regexpRestore = createRegExpRestore(),
 
         // 1. If options is not provided, then let options be undefined.
             options = arguments[1],
@@ -355,7 +355,7 @@ defineProperty(Intl.NumberFormat, 'supportedLocalesOf', {
             requestedLocales = CanonicalizeLocaleList(locales);
 
         // Restore the RegExp properties
-        regexpState.exp.test(regexpState.input);
+        regexpRestore();
 
         // 4. Return the result of calling the SupportedLocales abstract operation
         //    (defined in 9.2.8) with arguments availableLocales, requestedLocales,

--- a/src/12.datetimeformat.js
+++ b/src/12.datetimeformat.js
@@ -106,7 +106,7 @@ export function/* 12.1.1.1 */InitializeDateTimeFormat (dateTimeFormat, locales, 
     let internal = getInternalProperties(dateTimeFormat);
 
     // Create an object whose props can be used to restore the values of RegExp props
-    let regexpState = createRegExpRestore();
+    let regexpRestore = createRegExpRestore();
 
     // 1. If dateTimeFormat has an [[initializedIntlObject]] internal property with
     //    value true, throw a TypeError exception.
@@ -337,7 +337,7 @@ export function/* 12.1.1.1 */InitializeDateTimeFormat (dateTimeFormat, locales, 
         dateTimeFormat.format = GetFormatDateTime.call(dateTimeFormat);
 
     // Restore the RegExp properties
-    regexpState.exp.test(regexpState.input);
+    regexpRestore();
 
     // Return the newly initialised object
     return dateTimeFormat;
@@ -763,7 +763,7 @@ defineProperty(Intl.DateTimeFormat, 'supportedLocalesOf', {
             throw new TypeError('supportedLocalesOf() is not a constructor');
 
         // Create an object whose props can be used to restore the values of RegExp props
-        let regexpState = createRegExpRestore(),
+        let regexpRestore = createRegExpRestore(),
 
         // 1. If options is not provided, then let options be undefined.
             options = arguments[1],
@@ -779,7 +779,7 @@ defineProperty(Intl.DateTimeFormat, 'supportedLocalesOf', {
             requestedLocales = CanonicalizeLocaleList(locales);
 
         // Restore the RegExp properties
-        regexpState.exp.test(regexpState.input);
+        regexpRestore();
 
         // 4. Return the result of calling the SupportedLocales abstract operation
         //    (defined in 9.2.8) with arguments availableLocales, requestedLocales,

--- a/src/util.js
+++ b/src/util.js
@@ -171,7 +171,19 @@ export function createRegExpRestore () {
     // Create the regular expression that will reconstruct the RegExp properties
     ret.exp = new RegExp(arrJoin.call(reg, '') + lm, ml);
 
-    return ret;
+    return function() {
+      try {
+        ret.exp.test(ret.input);
+      } catch(e) {
+        // Warn instead of fail if RegExp was too big
+        if (e && e.message && e.message.slice(-14) === 'RegExp too big') {
+          console && console.warn && console.warn('Error restoring RegExp properties. RegExp too big.');
+        } else {
+          // Other issue, so rethrow
+          throw e;
+        }
+      }
+    };
 }
 
 /**

--- a/tests/sanity.js
+++ b/tests/sanity.js
@@ -52,3 +52,11 @@ assert(new IntlPolyfill.DateTimeFormat('en', {
     month:'long',
     year: 'numeric'
 }).format(new Date('2016/01/16')), 'January 2016', 'month should be long');
+
+// issue #196
+(new Array(32768 + 1)).join('a').match(/^a*$/);
+assert(new IntlPolyfill.NumberFormat('de-DE', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2
+}).format(0.015), "0,02", 'RegExp too big warning');
+'a'.match(/a/);


### PR DESCRIPTION
Fixes #196 

Different approach to #197 in that RegExp mutation avoidance is always preformed, but will not error out if the attempt to restore fails because the RegExp was too big.  

People that care about the properties being un-mutated will see the warning message and will have to fix their RegExp in such a way that it can be restored here.  

People that don't care about RegExp property mutation will not have failing.