### PR TITLE
Fix defineProperty to work with Java7 Rhino JS

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -6,7 +6,8 @@ const realDefineProp = (function () {
                     return 1;
                 }
             });
-            return sentinel.a === 1;
+            Object.defineProperty(sentinel, 'prototype', { writable: false });
+            return sentinel.a === 1 && sentinel.prototype instanceof Object;
         } catch (e) {
             return false;
         }

--- a/src/util.js
+++ b/src/util.js
@@ -1,5 +1,5 @@
 const realDefineProp = (function () {
-        let sentinel = {};
+        let sentinel = function(){};
         try {
             Object.defineProperty(sentinel, 'a', {
                 get: function () {


### PR DESCRIPTION
Apparently `Object.defineProperty(obj, 'prototype', { writable: false });` sets `obj.prototype` to `null` in Java7 Rhino JS. Naive version works, so update detection code to check that.