### PR TITLE
Add Test262Error to WRAPPER_START for tests to pass

### DIFF
--- a/tasks/update-tests.js
+++ b/tasks/update-tests.js
@@ -19,6 +19,9 @@ var WRAPPER_START = [
         'function fnGlobalObject() {',
         '    return __globalObject;',
         '}',
+        'function Test262Error(message) {',
+        '  this.message = message || "";',
+        '}',
 
         // Make sure polyfilled ECMA-262 functions are in place for the tests
         'IntlPolyfill.__applyLocaleSensitivePrototypes();'


### PR DESCRIPTION
This is needed for a couple of the getCanonicalLocales tests