### PR TITLE
Don't use Array.prototype.push in getCanonicalLocales

### DIFF
--- a/src/8.intl.js
+++ b/src/8.intl.js
@@ -16,8 +16,13 @@ Intl.getCanonicalLocales = function (locales) {
     // 2. Return CreateArrayFromList(ll).
     {
         let result = [];
-        for (let code in ll) {
-          result.push(ll[code]);
+
+        let len = ll.length;
+        let k = 0;
+
+        while (k < len) {
+            result[k] = ll[k];
+            k++;
         }
         return result;
     }


### PR DESCRIPTION
One of the tests262 tests if `Array.prototype.push` is used and it was in Intl.js. Let's fix it :)