### PR TITLE
More fixes for getCanonicalLocales test262 tests

### DIFF
--- a/src/8.intl.js
+++ b/src/8.intl.js
@@ -10,7 +10,7 @@ export const Intl = {};
 // 8.2.1
 // @spec[tc39/ecma402/master/spec/intl.html]
 // @clause[sec-intl.getcanonicallocales]
-Intl.getCanonicalLocales = function (locales) {
+function getCanonicalLocales (locales) {
     // 1. Let ll be ? CanonicalizeLocaleList(locales).
     let ll = CanonicalizeLocaleList(locales);
     // 2. Return CreateArrayFromList(ll).
@@ -26,4 +26,11 @@ Intl.getCanonicalLocales = function (locales) {
         }
         return result;
     }
-};
+}
+
+Object.defineProperty(Intl, 'getCanonicalLocales', {
+  enumerable: false,
+  configurable: true,
+  writable: true,
+  value: getCanonicalLocales
+});

--- a/src/9.negotiation.js
+++ b/src/9.negotiation.js
@@ -4,6 +4,7 @@
 import {
     List,
     toObject,
+    toLength,
     arrIndexOf,
     arrPush,
     arrSlice,
@@ -42,7 +43,7 @@ export function /* 9.2.1 */CanonicalizeLocaleList (locales) {
     // 5. Let lenValue be the result of calling the [[Get]] internal method of
     //    O with the argument "length".
     // 6. Let len be ToUint32(lenValue).
-    let len = O.length;
+    let len = toLength(O.length);
 
     // 7. Let k be 0.
     let k = 0;

--- a/src/util.js
+++ b/src/util.js
@@ -205,7 +205,38 @@ export function toObject (arg) {
     if (arg === null)
         throw new TypeError('Cannot convert null or undefined to object');
 
+    if (typeof arg === 'object')
+        return arg;
     return Object(arg);
+}
+
+export function toNumber (arg) {
+    if (typeof arg === 'number')
+        return arg;
+    return Number(arg);
+}
+
+export function toInteger (arg) {
+  let number = toNumber(arg);
+  if (isNaN(number))
+      return 0;
+  if (number === +0 ||
+      number === -0 ||
+      number === +Infinity ||
+      number === -Infinity)
+      return number;
+  if (number < 0)
+      return Math.floor(Math.abs(number)) * -1;
+  return Math.floor(Math.abs(number));
+}
+
+export function toLength (arg) {
+  let len = toInteger(arg);
+  if (len <= 0)
+      return 0;
+  if (len === Infinity)
+      return Math.pow(2, 53) - 1;
+  return Math.min(len, Math.pow(2, 53) - 1);
 }
 
 /**


### PR DESCRIPTION
Some more fixes to make us pass all-but-one getCanonicalLocales tests. I had to add `toLength` so that we properly deal with negative lengths etc.