### PR TITLE
Pass data.locale to Error message

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -56,7 +56,7 @@ defineProperty(Intl, '__applyLocaleSensitivePrototypes', {
 defineProperty(Intl, '__addLocaleData', {
     value: function (data) {
         if (!IsStructurallyValidLanguageTag(data.locale))
-            throw new Error("Object passed doesn't identify itself with a valid language tag");
+            throw new Error("Object passed (" + data.locale + ") doesn't identify itself with a valid language tag");
 
         addLocaleData(data, data.locale);
     }


### PR DESCRIPTION
Passing in the `data.locale` variable will help with debugging

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/andyearnshaw/intl.js/232)
<!-- Reviewable:end -->
