### PR TITLE
fix babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,6 @@
     ],
     "ignore": [
         "dist/*.js",
-        "lib/*.js",
         "locale-data/*.js"
     ]
 }


### PR DESCRIPTION
My problem described here https://github.com/facebook/react-native/issues/12071.

Babel can't handle `lib/core.js` file if `filename` option passed because babel is using your `.babelrc`.

`
var res = babel.transform(file, {
  code: false,
  filename: './node_modules/intl/lib/core.js',
});
`

I'm not sure why do you need ignore in `.babelrc` 
