### PR TITLE
Making sure that loading it with webpack resolves to non-polyfill whe…

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,4 +12,4 @@ if (!global.Intl) {
 }
 
 // providing an idiomatic api for the nodejs version of this module
-module.exports = global.IntlPolyfill;
+module.exports = global.Intl;


### PR DESCRIPTION
…n native support

Loading it with webpack would require additional checkings which are actually not required if we just return `global.Intl` as it is set to Polyfill anyway when no native support is given.