### PR TITLE
Updated documentation example for webpack 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,18 +73,17 @@ built-in `Intl`. An example of conditional usage using [webpack][] _might_ look 
 
 ```javascript
 function runMyApp() {
-    var nf = new Intl.NumberFormat(undefined, {style:'currency', currency:'GBP'});
-    document.getElementById('price').textContent = nf.format(100);
+    var nf = new Intl.NumberFormat(undefined, {
+        style: 'currency',
+        currency: 'GBP'
+    })
+    document.getElementById('price').textContent = nf.format(100)
 }
-if (!global.Intl) {
-    require.ensure([
-        'intl',
-        'intl/locale-data/jsonp/en.js'
-    ], function (require) {
-        require('intl');
-        require('intl/locale-data/jsonp/en.js');
-        runMyApp()
-    });
+const selectedLocale = 'en'
+if (!window.Intl) {
+    import('intl')
+        .then(() => import(`intl/locale-data/jsonp/${selectedLocale}.js`))
+        .then(runMyApp)
 } else {
     runMyApp()
 }


### PR DESCRIPTION
According to the latest webpack docs, "`require.ensure()` is specific to webpack and superseded by` import()`." (https://webpack.js.org/api/module-methods/#require-ensure). The new `import()` syntax aligns with the ES2015 spec (https://webpack.js.org/api/module-methods/#import-).

Note that the `require.ensure()` syntax relies on `Promise` internally, so if used with older browsers, a polyfill for `Promise` would be required. The `import()` syntax uses `Promises` explicitly, making this requirement more explicit to developers.

I pulled this code snippet from my application, which I tested in IE10 because it doesn't have support for `Intl`.