### PR TITLE
Fix the RegExp restoration tests

### DIFF
--- a/tests/sanity.js
+++ b/tests/sanity.js
@@ -59,9 +59,14 @@ var leftContext = RegExp.leftContext;
 var input = RegExp.input;
 var lastMatch = RegExp.lastMatch;
 new IntlPolyfill.NumberFormat('de-DE');
-assert(RegExp.leftContext, leftContext, 'RegExp.leftContext restored');
-assert(RegExp.input, input, 'RegExp.input restored');
-assert(RegExp.lastMatch, lastMatch, 'RegExp.lastMatch restored');
+// Since the console.log implementation used by the assert function can modifiy the RegExp,
+// we have to store the results before asserting them
+var actualLeftContext = RegExp.leftContext;
+var actualInput = RegExp.input;
+var actualLastMatch = RegExp.lastMatch;
+assert(actualLeftContext, leftContext, 'RegExp.leftContext restored');
+assert(actualInput, input, 'RegExp.input restored');
+assert(actualLastMatch, lastMatch, 'RegExp.lastMatch restored');
 'a'.match(/a/);
 
 // Issues #190, #192


### PR DESCRIPTION
I chose to copy the results before the assertions. Another fix would be to disable [this code](https://github.com/nodejs/node/blob/9deca876bb94626564184ad263ff80dc8042808b/lib/internal/tty.js#L70) by setting the `NODE_DISABLE_COLORS` variable. But IMHO that'd still be flaky.